### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,9 @@
 name: "Code scanning - action"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/hsaito/MyNumber.NET/security/code-scanning/2](https://github.com/hsaito/MyNumber.NET/security/code-scanning/2)

The problem can be fixed by adding an explicit `permissions` block at the top workflow level or inside the relevant job. As this workflow only contains a single job (`CodeQL-Build`), we can add a `permissions:` block at the workflow level, immediately following the `name:` or after `on:` (anywhere at the root, before `jobs:`), or within the `CodeQL-Build` job. The minimal recommended permissions for CodeQL analysis are `contents: read` (to fetch code) and `security-events: write` (to upload analysis results). This ensures the GITHUB_TOKEN only has these specific permissions when running this workflow, following least privilege. This change can be made within `.github/workflows/codeql-analysis.yml`, by inserting the following block at the top level:

```yaml
permissions:
  contents: read
  security-events: write
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
