### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hsaito/MyNumber.NET/security/code-scanning/1](https://github.com/hsaito/MyNumber.NET/security/code-scanning/1)

In general, to fix this problem, you should add an explicit `permissions` block at the root of the workflow or at the job level. This block should grant no more than the least privileges necessary for successful execution.

For this workflow, the steps are limited to source code checkout, package setup, restoring dependencies, building and testing a .NET project. None of these steps require `write` permissions or any scope beyond reading repository contents. Thus, the minimal and correct fix is to add a top-level `permissions` block granting only `contents: read`, just below the `name:` key and above `on:`, so that it applies to all jobs in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
